### PR TITLE
Simple nonwmf k8s

### DIFF
--- a/k8sh/exec.py
+++ b/k8sh/exec.py
@@ -52,13 +52,14 @@ class Kubectl:
     cluster: str = attr.ib()
     namespace: Optional[str] = attr.ib()
     remote: RemoteCommand = attr.ib()
-    kubeconfig_fmt = "KUBECONFIG=/etc/kubernetes/{namespace}-{cluster}.config"
+    #kubeconfig_fmt = "KUBECONFIG=/etc/kubernetes/{namespace}-{cluster}.config"
+    kubeconfig_fmt = "KUBECONFIG=/etc/kubernetes/admin.conf"
 
     def _kubeconfig(self, admin: bool = False) -> str:
         """Returns the kubeconfig file path."""
         if admin:
             # If the command is to be run as admin, we search for the admin kubeconfig
-            return "sudo " + self.kubeconfig_fmt.format(
+            return self.kubeconfig_fmt.format(
                 namespace="admin", cluster=self.cluster
             )
         else:
@@ -69,11 +70,11 @@ class Kubectl:
     def _kubectl(self, command: str, admin: bool = False) -> List[str]:
         """Returns the full command array for a kubectl invocation."""
         if self.namespace is not None:
-            _cmd = "{} kubectl -n {} {}".format(
+            _cmd = "sudo kubectl --kubeconfig {} -n {} {}".format(
                 self._kubeconfig(admin), self.namespace, command
             )
         else:
-            _cmd = "{} kubectl {}".format(self._kubeconfig(admin), command)
+            _cmd = "kubectl --kubeconfig {} {}".format(self._kubeconfig(admin), command)
         return shlex.split(_cmd)
 
     def run_sync(self, command: str, admin: bool = False):

--- a/k8sh/exec.py
+++ b/k8sh/exec.py
@@ -52,8 +52,7 @@ class Kubectl:
     cluster: str = attr.ib()
     namespace: Optional[str] = attr.ib()
     remote: RemoteCommand = attr.ib()
-    #kubeconfig_fmt = "KUBECONFIG=/etc/kubernetes/{namespace}-{cluster}.config"
-    kubeconfig_fmt = "KUBECONFIG=/etc/kubernetes/admin.conf"
+    kubeconfig_fmt = "KUBECONFIG=/etc/kubernetes/{namespace}-{cluster}.config"
 
     def _kubeconfig(self, admin: bool = False) -> str:
         """Returns the kubeconfig file path."""


### PR DESCRIPTION
I was not able to run k8sh on a simple k8s cluster that I have setup on horizon, eben by setting the kubeconfig in .k8shrc. Using the --kubeconfig parameter to kubectl works for me now.

to test: 

- k8s runs on kubespray1.k8splay.eqiad.wmflabs, also kubespray2 and 3.
- admin.conf is in /etc/kubernetes and is the only config file
- tested with local kubectl and with remote ssh kubectl on kubespray1
  - when local kubectl I had a SSH port forwarding setup to kuespary1 for 6443.
