### PR TITLE
Standardize config file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Configuration of the shell is pretty simple, and is done by writing a yaml file.
 
 (Yes, the configuration file is in yaml. It's kubernetes, what did you expect?)
 
-Anyways, the file, located at `~/.k8shrc.yaml` can contain any of the following 
+Anyways, the file, located at `~/.config/k8shrc.yaml` can contain any of the following
 configuration keys:
 
 * `kubectl_host`: The host to ssh into to run kubectl. If you can run kubectl 
@@ -37,7 +37,7 @@ It treats, quite simplistically, a cluster like a filesystem hierarchy where:
 are consequent directories in the hierarchy. While the cluster needs to be chosen with `use <cluster>`, all the other levels can be navigated with `cd <what>` and `ls`. For example, let's say we need to inspect the logs of an application called `gatekeeper` running within the `production` cluster, in namespace `auth` 
 
 ```bash
-$ kubesh
+$ k8sh
 # first thing we need to do is to select a cluster
 NONE (root) $ use production
 # let's see all the available namespaces

--- a/k8sh/__init__.py
+++ b/k8sh/__init__.py
@@ -7,13 +7,16 @@ allows you to drill down from cluster to namespace, to pods/deployments, and fro
 to individual containers, allowing you to inspect them and execute processes in
 their namespaces.
 """
+from pathlib import Path
 from typing import Optional, List
 import enum
+import warnings
 
 import yaml
 import os
 
 from colorama import Fore, Style, init
+from xdg import XDG_CONFIG_HOME
 import attr
 
 
@@ -101,3 +104,14 @@ class KubeContext:
             return self.env[idx - 1]
         except IndexError:
             return None
+
+def k8shConfigPath() -> Path:
+    filename = "k8shrc.yaml"
+    xdgpath = XDG_CONFIG_HOME.joinpath(filename)
+    legacypath = Path.home().joinpath(f".{filename}")
+    if xdgpath.is_file():
+        return xdgpath
+    elif legacypath.is_file():
+        warnings.warn(f"Config path {legacypath} is deprecated, please use {xdgpath} instead")
+        return legacypath
+    return xdgpath

--- a/k8sh/shell.py
+++ b/k8sh/shell.py
@@ -4,7 +4,7 @@ import shlex
 import copy
 from typing import Any, Dict, Optional, Tuple
 
-from k8sh import Ctx, KubeContext, blue, k8shError, red, setup
+from k8sh import k8shConfigPath, Ctx, KubeContext, blue, k8shError, red, setup
 from k8sh.exec import Kubectl, RemoteCommand
 
 CAT_NAV = "Kubernetes navigation"
@@ -325,6 +325,6 @@ def from_configfile(path: str) -> KubeCmd:
 
 
 def main():
-    configfile = os.path.expanduser("~/.k8shrc.yaml")
+    configfile = k8shConfigPath()
     sh = from_configfile(configfile)
     sh.cmdloop()

--- a/run.py
+++ b/run.py
@@ -1,10 +1,10 @@
 import os
 
-from k8sh import shell
+from k8sh import k8shConfigPath, shell
 
 
 def main():
-    configfile = os.path.expanduser("~/.k8shrc.yaml")
+    configfile = k8shConfigPath()
     sh = shell.from_configfile(configfile)
     sh.cmdloop()
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     author='Giuseppe Lavagetto',
     author_email='lavagetto@gmail.com',
     url='https://github.com/lavagetto/k8sh',
-    install_requires=['cmd2', 'pyyaml'],
+    install_requires=['cmd2', 'pyyaml', 'xdg'],
     zip_safe=False,
     packages=find_packages(),
     entry_points={


### PR DESCRIPTION
Use $XDG_CONFIG_HOME as directory for the k8shrc.yaml file.
For existing setups, ~/.k8shrc.yaml will still be used, but a
UserWarning will be shown.